### PR TITLE
Fix encoding

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,11 @@
 name=R4HttpClient
 version=1.0.0
-author=Princetoniño Piscos <princepiscos@gmail.com>
-maintainer=Princetoniño Piscos <princepiscos@gmail.com>
+author=PrincetoniÃ±o Piscos <princepiscos@gmail.com>
+maintainer=PrincetoniÃ±o Piscos <princepiscos@gmail.com>
 sentence=A lightweight HTTP client library for Arduino Uno R4 WiFi.
 paragraph=A wrapper for Arduino UNO R4 WiFi microcontroller WiFiS3 HttpClient with functionality of GET & POST.
 category=Communication
 url=https://github.com/piscodev/r4httpclient
 architectures=renesas_uno
 includes=R4HttpClient.h
+


### PR DESCRIPTION
the 'ñ' in author field was getting mangled when propagating to arduino/pio registries, fixed by transcoding the file to utf8

see https://fosstodon.org/@arduinoLibs/113205394348024518